### PR TITLE
Linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,7 @@
       "node": true,
       "jest": true,
       "detox/detox": true,
-      "jasmine":true
+      "jasmine": true
   },
   "extends": "eslint-config-semistandard",
   "parser": "babel-eslint",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,9 @@
       "browser": true,
       "commonjs": true,
       "es6": true,
-      "node": true
+      "node": true,
+      "jest": true,
+      "detox/detox": true
   },
   "extends": "eslint-config-semistandard",
   "parser": "babel-eslint",
@@ -16,7 +18,8 @@
   },
   "plugins": [
       "react",
-      "flowtype"
+      "flowtype",
+      "detox"
   ],
   "rules": {
       "indent": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,8 @@
       "es6": true,
       "node": true,
       "jest": true,
-      "detox/detox": true
+      "detox/detox": true,
+      "jasmine":true
   },
   "extends": "eslint-config-semistandard",
   "parser": "babel-eslint",

--- a/devDependencies.json
+++ b/devDependencies.json
@@ -16,6 +16,7 @@
   "eslint": "^4.19.1",
   "eslint-config-semistandard": "^11.0.0",
   "eslint-config-standard": "^10.2.1",
+  "eslint-plugin-detox": "^1.0.0",
   "eslint-plugin-flowtype": "^2.39.1",
   "eslint-plugin-import": "^2.7.0",
   "eslint-plugin-node": "^5.2.0",

--- a/e2e/init.js
+++ b/e2e/init.js
@@ -3,7 +3,7 @@ const config = require('../package.json').detox;
 const adapter = require('detox/runners/jest/adapter');
 
 jest.setTimeout(120000);
-jasmine.getEnv().addReporter(adapter); 
+jasmine.getEnv().addReporter(adapter);
 
 beforeAll(async () => {
   await detox.init(config);

--- a/e2e/init.js
+++ b/e2e/init.js
@@ -3,7 +3,7 @@ const config = require('../package.json').detox;
 const adapter = require('detox/runners/jest/adapter');
 
 jest.setTimeout(120000);
-jasmine.getEnv().addReporter(adapter); // eslint-disable-line no-undef
+jasmine.getEnv().addReporter(adapter); 
 
 beforeAll(async () => {
   await detox.init(config);

--- a/e2e/init.js
+++ b/e2e/init.js
@@ -3,7 +3,7 @@ const config = require('../package.json').detox;
 const adapter = require('detox/runners/jest/adapter');
 
 jest.setTimeout(120000);
-jasmine.getEnv().addReporter(adapter);
+jasmine.getEnv().addReporter(adapter); // eslint-disable-line no-undef
 
 beforeAll(async () => {
   await detox.init(config);


### PR DESCRIPTION
Jest, Jasmine and Detox  are causing eslint to produce errors. 
Adding `"jest":true` to the environment variables solves the problem with Jest.
Adding `"jasmine":true` solves the problem with Jasmine.
Add the Detox plugin for eslint and adding `"detox/detox": true` solves the problem with Detox. 