### PR TITLE
Set a default backgroundColor

### DIFF
--- a/storybook/index.js
+++ b/storybook/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { AppRegistry } from 'react-native';
+import { AppRegistry, View } from 'react-native';
 import { getStorybookUI, configure } from '@storybook/react-native';
 
 import './rn-addons';
@@ -14,9 +14,11 @@ configure(() => {
 const StorybookUIRoot = getStorybookUI({});
 
 class StorybookUIHMRRoot extends Component {
-  render () {
-    return <StorybookUIRoot />;
-  }
+  return (
+    <View style={{ backgroundColor: 'grey', flex: 1 }}>
+      <StorybookUIRoot />
+    </View>
+  );
 }
 
 // If you are using React Native vanilla and after installation you don't see your app name here, write it manually.


### PR DESCRIPTION
With the react-native 0.58.+ having implemented a black background in the `AppDelegate.m` it means that storybook is difficult to see as the black text on a black background doesn't work.